### PR TITLE
TT-1211: upgrade dropwizard to 1.1.4

### DIFF
--- a/common-test-utils/build.gradle
+++ b/common-test-utils/build.gradle
@@ -5,12 +5,9 @@ dependencies {
             "com.google.guava:guava:16.0",
             'org.eclipse.jetty:jetty-server:9.0.7.v20131107',
             'com.google.guava:guava:16.0',
-            'com.fasterxml.jackson.core:jackson-annotations:2.3.1',
-            'com.fasterxml.jackson.core:jackson-core:2.3.1',
-            'com.fasterxml.jackson.core:jackson-databind:2.3.1',
             'commons-lang:commons-lang:2.6',
             'commons-io:commons-io:2.4',
-            'io.dropwizard:dropwizard-jackson:0.8.1',
-            'io.dropwizard:dropwizard-client:0.8.1'
+            'io.dropwizard:dropwizard-jackson:1.1.4',
+            'io.dropwizard:dropwizard-client:1.1.4'
 
 }


### PR DESCRIPTION
And delete unnecessary jackson dependencies from gradle file

Authors: @hugh-emerson, @michaelwalker