### PR TITLE
49: Upgrade Dropwizard to 1.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ repositories {
     maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
 }
 
+ext {
+    dropwizard_version = "1.3.5"
+}
+
 dependencies {
     compile 'junit:junit:4.11',
             'org.assertj:assertj-core:1.6.0',
@@ -19,8 +23,8 @@ dependencies {
             'com.google.guava:guava:16.0',
             'commons-lang:commons-lang:2.6',
             'commons-io:commons-io:2.4',
-            'io.dropwizard:dropwizard-jackson:1.1.4',
-            'io.dropwizard:dropwizard-client:1.1.4'
+            "io.dropwizard:dropwizard-jackson:$dropwizard_version",
+            "io.dropwizard:dropwizard-client:$dropwizard_version"
 
 }
 


### PR DESCRIPTION
Upgrade Dropwizard to 1.3.5 to fix various security issues.

Authors: @adityapahuja