### PR TITLE
BAU: Add OpenJDK 8 back to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - openjdk11
+  - openjdk8
 before_install:
 # this is a hack, so PR builds can be tested in travis
   - perl -i -0pe 's/maven[\s\{]+[^\{\}]*\}/maven { url \"https:\/\/build.shibboleth.net\/nexus\/content\/groups\/public\" \n url \"https:\/\/repo1.maven.org\/maven2\" \n jcenter() }/gms' build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,11 @@ plugins { id "com.jfrog.bintray" version "1.8.4" }
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 def buildVersion = "2.0.0-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 group = "uk.gov.ida"
 version = "$buildVersion"


### PR DESCRIPTION
VSP and MSA are still using Java 8. This change adds OpenJDK 8 back to Travis and updates gradle build file to set both source and target compatibility to Java 8.

Author: @adityapahuja