### PR TITLE
BAU: Upgrade test libraries to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,21 +16,21 @@ repositories {
 }
 
 ext {
-    dropwizard_version = "1.3.5"
+    dropwizard_version = "1.3.17"
 }
 
 dependencies {
-    implementation  'junit:junit:4.11',
-                    'com.google.guava:guava:16.0',
+    implementation  'org.junit.jupiter:junit-jupiter-api:5.5.2',
+                    'org.junit.jupiter:junit-jupiter-migrationsupport:5.5.2',
+                    'com.google.guava:guava:28.1-jre',
                     'org.eclipse.jetty:jetty-server:9.0.7.v20131107',
-                    'com.google.guava:guava:16.0',
                     'commons-lang:commons-lang:2.6',
                     'commons-io:commons-io:2.4',
                     "io.dropwizard:dropwizard-jackson:$dropwizard_version",
                     "io.dropwizard:dropwizard-client:$dropwizard_version"
 
     testImplementation  'org.assertj:assertj-core:3.14.0',
-                        'org.mockito:mockito-core:3.1.0'
+                        'org.mockito:mockito-core:3.2.0'
 }
 
 task sourceJar(type: Jar) {


### PR DESCRIPTION
Add `junit-jupiter-migrationsupport` to keep compatibility with JUnit 4 classes we're still using.
