### PR TITLE
EXErxpzy - Replace whitelist with allowlist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ group = "uk.gov.ida"
 version = "$buildVersion"
 
 repositories {
-    maven { url 'https://gds.jfrog.io/artifactory/whitelisted-repos' }
+    maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
 }
 
 ext {


### PR DESCRIPTION
- We are replacing whitelist-repos with allowed-repos. We are running both for now so we can switch it over.