### PR TITLE
HUB-907: Build with `api` configuration for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ jdk:
 before_install:
 # this is a hack, so PR builds can be tested in travis
   - perl -i -0pe 's/maven[\s\{]+[^\{\}]*\}/maven { url \"https:\/\/build.shibboleth.net\/nexus\/content\/groups\/public\" \n url \"https:\/\/repo1.maven.org\/maven2\" \n jcenter() }/gms' build.gradle
-script: ./gradlew assemble -x signArchives

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins { 
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
@@ -33,8 +33,9 @@ dependencies {
                     'org.eclipse.jetty:jetty-server:9.0.7.v20131107',
                     'commons-lang:commons-lang:2.6',
                     'commons-io:commons-io:2.4',
-                    "io.dropwizard:dropwizard-jackson:$dropwizard_version",
-                    "io.dropwizard:dropwizard-client:$dropwizard_version"
+                    "io.dropwizard:dropwizard-jackson:$dropwizard_version"
+
+    api  "io.dropwizard:dropwizard-client:$dropwizard_version"
 
     testImplementation  'org.assertj:assertj-core:3.14.0',
                         'org.mockito:mockito-core:3.2.0'


### PR DESCRIPTION
The `baseUri` method on `HttpStubRule` returns a `UriBuilder`. This is a
type defined in a dependency.

Projects consuming this library will need to have access to that type at
compile time. Moving the dependency to the `api` configuration allows
that to happen.

The `java-library` plugin gives us the `api` configuration. Using this
means the dependencies *are* exposed to the consuming projects compile
time.

This change is being prompted as a consuming project is unable to
compile due to missing these dependencies.