### PR TITLE
Add archive banner to prepare for repo archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-
 # SAML Test Utils
 
-[![Build Status](https://travis-ci.org/alphagov/verify-test-utils.svg?branch=master)](https://travis-ci.org/alphagov/verify-test-utils)
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
 
 Library for various SAML testing utility operations. These include:
 


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.